### PR TITLE
Merchant Trading command fixes 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx4G
 name=RockyCore
-mod_version=0.3.0
+mod_version=0.4.1
 mc_version=1.12.2
-mcp_mappings=snapshot_20171003
-forge_version=14.23.1.2555
-ct_version=4.0.9.289+
+mcp_mappings=stable_39
+forge_version=14.23.4.2765
+ct_version=4.1.11+
 mtlib_version=3.0.0.1+
 jei_version=4.8.5.132

--- a/src/main/java/rocks/devonthe/rockycore/crafttweaker/merchant/MerchantTradeHandler.java
+++ b/src/main/java/rocks/devonthe/rockycore/crafttweaker/merchant/MerchantTradeHandler.java
@@ -9,7 +9,6 @@ import com.google.common.collect.Lists;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
-import crafttweaker.mc1120.commands.CTChatCommand;
 import java.util.List;
 import net.minecraftforge.fml.common.registry.VillagerRegistry;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -22,10 +21,6 @@ public class MerchantTradeHandler {
   protected static final String name = "Merchant";
   private static List<MerchantTrade> trades = Lists.newArrayList();
 
-  static {
-    CTChatCommand.registerCommand(new MerchantCommand());
-  }
-
   @ZenMethod
   public static void addTrade(String profession, String career, IItemStack buy1, IItemStack buy2,
       IItemStack sell, int level) {
@@ -36,7 +31,7 @@ public class MerchantTradeHandler {
     Preconditions.checkArgument(VillagerHelper.getCareer(p1, career).isPresent());
     Preconditions.checkNotNull(buy1);
     Preconditions.checkNotNull(sell);
-    Preconditions.checkArgument(level > 0);
+    Preconditions.checkArgument(level >= 0);
     CraftTweakerAPI.apply(new MerchantTradeHandler.Add(
         new MerchantTrade(p1, VillagerHelper.getCareer(p1, career).get(), toStack(buy1),
             toStack(buy2), toStack(sell), level)));

--- a/src/main/java/rocks/devonthe/rockycore/crafttweaker/merchant/MerchantTradeHandler.java
+++ b/src/main/java/rocks/devonthe/rockycore/crafttweaker/merchant/MerchantTradeHandler.java
@@ -31,7 +31,7 @@ public class MerchantTradeHandler {
     Preconditions.checkArgument(VillagerHelper.getCareer(p1, career).isPresent());
     Preconditions.checkNotNull(buy1);
     Preconditions.checkNotNull(sell);
-    Preconditions.checkArgument(level >= 0);
+    Preconditions.checkArgument(level > 0);
     CraftTweakerAPI.apply(new MerchantTradeHandler.Add(
         new MerchantTrade(p1, VillagerHelper.getCareer(p1, career).get(), toStack(buy1),
             toStack(buy2), toStack(sell), level)));

--- a/src/main/java/rocks/devonthe/rockycore/proxy/CommonProxy.java
+++ b/src/main/java/rocks/devonthe/rockycore/proxy/CommonProxy.java
@@ -1,10 +1,13 @@
 package rocks.devonthe.rockycore.proxy;
 
+import crafttweaker.mc1120.commands.CTChatCommand;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import rocks.devonthe.rockycore.crafttweaker.merchant.MerchantCommand;
 
 public class CommonProxy {
 
   public void init(FMLInitializationEvent event) {
+    CTChatCommand.registerCommand(new MerchantCommand());
     // noop
   }
 }


### PR DESCRIPTION
 - Fixed the registration of the Merchant Trading command(s). Fixes #10 
This needs to be done in an FML loading stage so at the moment this gets executed, it's certain that CraftTweaker has actually loaded the required logic.
 - updated gradle.properties
-increased mod version
-updated mappings
-updated forge version
-updated craft tweaker version